### PR TITLE
Personal2 tethering when boot

### DIFF
--- a/common/params.cc
+++ b/common/params.cc
@@ -89,6 +89,7 @@ std::unordered_map<std::string, uint32_t> keys = {
     {"AthenadPid", PERSISTENT},
     {"AthenadUploadQueue", PERSISTENT},
     {"CalibrationParams", PERSISTENT},
+    {"HotspotWhenStart", PERSISTENT},
     {"CameraDebugExpGain", CLEAR_ON_MANAGER_START},
     {"CameraDebugExpTime", CLEAR_ON_MANAGER_START},
     {"CarBatteryCapacity", PERSISTENT},

--- a/common/version.h
+++ b/common/version.h
@@ -1,1 +1,1 @@
-#define COMMA_VERSION "0.9.1"
+#define COMMA_VERSION "0.9.1-tethering-enabled"

--- a/selfdrive/manager/manager.py
+++ b/selfdrive/manager/manager.py
@@ -39,6 +39,7 @@ def manager_init() -> None:
     ("DisengageOnAccelerator", "1"),
     ("GsmMetered", "1"),
     ("HasAcceptedTerms", "0"),
+    ("HotspotWhenStart", "0"),
     ("LanguageSetting", "main_en"),
     ("OpenpilotEnabledToggle", "1"),
   ]
@@ -47,6 +48,11 @@ def manager_init() -> None:
 
   if params.get_bool("RecordFrontLock"):
     params.put_bool("RecordFront", True)
+
+  # Set Tethering when boot
+  hotspot_is_enabled = params.get_bool("HotspotWhenStart")
+  if hotspot_is_enabled:
+    os.system('nmcli con up Hotspot')
 
   # set unset params
   for k, v in default_params:

--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -204,8 +204,8 @@ void AdvancedNetworking::refresh() {
 }
 
 void AdvancedNetworking::toggleTethering(bool enabled) {
-  wifi->setTetheringEnabled(enabled);
   Hardware::set_tethering_enabled(enabled);
+  wifi->setTetheringEnabled(enabled);
   tetheringToggle->setEnabled(false);
 }
 

--- a/selfdrive/ui/qt/offroad/networking.cc
+++ b/selfdrive/ui/qt/offroad/networking.cc
@@ -205,6 +205,7 @@ void AdvancedNetworking::refresh() {
 
 void AdvancedNetworking::toggleTethering(bool enabled) {
   wifi->setTetheringEnabled(enabled);
+  Hardware::set_tethering_enabled(enabled);
   tetheringToggle->setEnabled(false);
 }
 

--- a/selfdrive/ui/qt/offroad/networking.h
+++ b/selfdrive/ui/qt/offroad/networking.h
@@ -8,6 +8,7 @@
 #include "selfdrive/ui/qt/widgets/input.h"
 #include "selfdrive/ui/qt/widgets/ssh_keys.h"
 #include "selfdrive/ui/qt/widgets/toggle.h"
+#include "selfdrive/hardware/hw.h"
 
 class WifiUI : public QWidget {
   Q_OBJECT

--- a/system/hardware/tici/hardware.h
+++ b/system/hardware/tici/hardware.h
@@ -50,4 +50,7 @@ public:
 
   static bool get_ssh_enabled() { return Params().getBool("SshEnabled"); };
   static void set_ssh_enabled(bool enabled) { Params().putBool("SshEnabled", enabled); };
+
+  static bool get_tethering_enabled() {return Params().getBool("HotspotWhenStart");}
+  static void set_tethering_enabled(bool enabled) { Params().putBool("HotspotWhenStart", enabled); };
 };


### PR DESCRIPTION
#Feature: 
- Persistencia do tethering quando reiniciado.

#Casos:
1 - Se o device for desligado com o **tethering ativado** assim que device iniciar o **tethering continua ativo**
2 - Se o device for desligado com o **tethering desativado** assim que o device iniciar o **tethering continua desativo**

#Testes:
1 - Instalação feita do zero com o código modificado