### PR TITLE
Car Port: 2026 GWM Haval H6 PHEV (MK4)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
   url = ../../commaai/panda.git
 [submodule "opendbc"]
   path = opendbc_repo
-  url = ../../commaai/opendbc.git
+  url = https://github.com/nGoline/opendbc.git
 [submodule "msgq"]
   path = msgq_repo
   url = ../../commaai/msgq.git

--- a/launch_env.sh
+++ b/launch_env.sh
@@ -19,6 +19,4 @@ if [ -z "$AGNOS_VERSION" ]; then
   export AGNOS_VERSION="17.2"
 fi
 
-export SKIP_FW_QUERY=1
-export FINGERPRINT=GWM_HAVAL_H6
 export STAGING_ROOT="/data/safe_staging"


### PR DESCRIPTION
**Car Port: 2026 GWM Haval H6 PHEV (MK4)**

  Adds the `GWM_HAVAL_H6_MK4` platform — the 2026 Haval H6 plug-in hybrid, which
  shares the GWM platform with Sato's 2024 H6 HEV but uses a different CAN layout
  (new DBC, 0x12e CAR_OVERALL_SIGNALS, angle-based STEER_CMD). All changes are
  fingerprint-gated; MK3 (2023 HEV) behavior is untouched.

  **Checklist**

  - [x] added entry to CAR in `opendbc/car/gwm/values.py` and ran `opendbc/car/docs.py` to generate new docs
  - [ ] test route added to [routes.py](https://github.com/commaai/opendbc/blob/master/opendbc/car/tests/routes.py)
  - [x] route with openpilot: `04219e6204e40222|000000c3--ef84fdc95e`
  - [x] route with stock system: `04219e6204e40222|000000c0--414cac01c8`
  - [ ] car harness used: N/A (GWM harness, not sold by comma — reuses the existing GWM platform from the H6 HEV port)